### PR TITLE
Feature/load wav resample quick

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ for example, the model trained with ResNet34s trained by adam with softmax, and 
         VoxCeleb1-Test-E: 3.24      VoxCeleb1-Test-E-Cleaned: 3.13
         VoxCeleb1-Test-H: 5.17      VoxCeleb1-Test-H-Cleaned: 5.06
 
+### Fine Tuning the model
+The weights provided do not include the weights of the final prediction layer, so one needs to randomly initialise this with `network.load_weights(os.path.join(args.resume), by_name=True, skip_mismatch=True)` in main.py
+
+python main.py --net resnet34s --gpu 0  --ghost_cluster 2 --vlad_cluster 8 --batch_size 16 --lr 0.001 --warmup_ratio 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --data_path /media/ben/datadrive/Zalo/voice-verification/Train-Test-Data/dataset/ --resume=/media/ben/datadrive/Software/VGG-Speaker-Recognition/model/weights_dropbox.h5
+
+
 ### Licence
 The code and mode are available to download for commercial/research purposes under a Creative Commons Attribution 4.0 International License(https://creativecommons.org/licenses/by/4.0/).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # conda install cudatoolkit==9.0 then linked to an environment with export LD_LIBRARY_PATH=/home/ben/anaconda3/envs/entrance/lib:$LD_LIBRARY_PATH missing libcudnn.so.7
+# conda install llvmlite==0.31.0
 keras==2.2.4
 tensorflow-gpu==1.8.0
-librosa==0.3.1
+librosa==0.5.0 # librosa-0.7.2
 scikit-learn==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # conda install llvmlite==0.31.0
 keras==2.2.4
 tensorflow-gpu==1.8.0
-librosa==0.7.2
+librosa==0.6.3
 scikit-learn==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # conda install llvmlite==0.31.0
 keras==2.2.4
 tensorflow-gpu==1.8.0
-librosa==0.5.0 # librosa-0.7.2
+librosa==0.7.2
 scikit-learn==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# conda install cudatoolkit==9.0 then linked to an environment with export LD_LIBRARY_PATH=/home/ben/anaconda3/envs/entrance/lib:$LD_LIBRARY_PATH missing libcudnn.so.7
+keras==2.2.4
+tensorflow-gpu==1.8.0
+librosa==0.3.1
+scikit-learn==0.16.1

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import sys
 import keras
 import numpy as np
 
+np.seterr(all='raise')
 sys.path.append('../tool')
 import toolkits
 
@@ -35,8 +36,7 @@ parser.add_argument('--ohem_level', default=0, type=int,
                     help='pick hard samples from (ohem_level * batch_size) proposals, must be > 1')
 global args
 args = parser.parse_args()
-import numpy as np
-np.seterr(all='raise')
+
 def main():
 
     # gpu configuration
@@ -76,8 +76,6 @@ def main():
                                            mode='train', args=args)
     # ==> load pre-trained model ???
     mgpu = len(keras.backend.tensorflow_backend._get_available_gpus())
-    #import pdb
-    #pdb.set_trace()
 
     print("mpu", mgpu)
     if args.resume:
@@ -85,9 +83,9 @@ def main():
         if args.resume:
             if os.path.isfile(args.resume):
                 if mgpu == 1:
-                    # by_name=True, skip_mismatch=True
                     # https://github.com/WeidiXie/VGG-Speaker-Recognition/issues/46
-                    network.load_weights(os.path.join(args.resume), by_name=True, skip_mismatch=True)
+                    network.load_weights(os.path.join(args.resume), by_name=True,
+                                         skip_mismatch=True)
                 else:
                     print("loading N+1", mgpu)
                     network.layers[mgpu + 1].load_weights(os.path.join(args.resume))

--- a/src/predict.py
+++ b/src/predict.py
@@ -44,7 +44,7 @@ def main():
     print('==> calculating test({}) data lists...'.format(args.test_type))
 
     if args.test_type == 'normal':
-        verify_list = np.loadtxt('../meta/voxceleb1_veri_test.txt', str)
+        verify_list = np.loadtxt('/media/ben/datadrive/Zalo/voice-verification/vgg_db_files/val_trials.txt', str)
     elif args.test_type == 'hard':
         verify_list = np.loadtxt('../meta/voxceleb1_veri_test_hard.txt', str)
     elif args.test_type == 'extend':
@@ -133,6 +133,7 @@ def main():
 def set_result_path(args):
     model_path = args.resume
     exp_path = model_path.split(os.sep)
+    print("Paths are", '../result', exp_path[2], exp_path[3])
     result_path = os.path.join('../result', exp_path[2], exp_path[3])
     if not os.path.exists(result_path): os.makedirs(result_path)
     return result_path

--- a/src/train.sh
+++ b/src/train.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=/home/ben/anaconda3/envs/entrance/lib:$LD_LIBRARY_PATH
+
+python main.py --net resnet34s --gpu 0  --ghost_cluster 2 --vlad_cluster 8 --batch_size 16 --lr 0.001 --warmup_ratio 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --data_path /media/ben/datadrive/Zalo/voice-verification/Train-Test-Data/dataset/ --resume=/media/ben/datadrive/Software/VGG-Speaker-Recognition/model/weights_dropbox.h5

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,53 +10,9 @@ import librosa
 from scipy import signal
 
 
-# ===============================================
-#       code from Arsha for loading data.
-# ===============================================
-def read_audio(current_file, sample_rate=None, mono=True):
-    """Read audio file
-    Parameters
-    ----------
-    current_file : str
-    sample_rate: int, optional
-        Target sampling rate. Defaults to using native sampling rate.
-    mono : int, optional
-        Convert multi-channel to mono. Defaults to True.
-    Returns
-    -------
-    y : (n_samples, n_channels) np.array
-        Audio samples.
-    sample_rate : int
-        Sampling rate.
-    Notes
-    -----
-    """
-
-    y, file_sample_rate = sf.read(
-        current_file, dtype="float32", always_2d=True
-    )
-
-    # convert to mono
-    if mono and y.shape[1] > 1:
-        y = np.mean(y, axis=1, keepdims=True)
-
-    # resample if sample rates mismatch
-    if (sample_rate is not None) and (file_sample_rate != sample_rate):
-        if y.shape[1] == 1:
-            # librosa expects mono audio to be of shape (n,), but we have (n, 1).
-            y = librosa.core.resample(y[:, 0], file_sample_rate, sample_rate)[:, None]
-        else:
-            y = librosa.core.resample(y.T, file_sample_rate, sample_rate).T
-    else:
-        sample_rate = file_sample_rate
-
-    return y, sample_rate
-
 def load_wav(vid_path, sr, mode='train'):
+    wav, sr_ret = librosa.load(vid_path, sr=sr)
 
-    wav, sr_ret = read_audio(vid_path, sample_rate=sr, mono=True)
-    
-    print("finish loading wav", timelib.time()-t1)
     if mode == 'train':
         extended_wav = np.append(wav, wav)
         if np.random.random() < 0.3:

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,27 +6,57 @@ import scipy
 import soundfile as sf
 import scipy.signal as sps
 from scipy import interpolate
+import librosa
+from scipy import signal
+
+
 # ===============================================
 #       code from Arsha for loading data.
 # ===============================================
+def read_audio(current_file, sample_rate=None, mono=True):
+    """Read audio file
+    Parameters
+    ----------
+    current_file : str
+    sample_rate: int, optional
+        Target sampling rate. Defaults to using native sampling rate.
+    mono : int, optional
+        Convert multi-channel to mono. Defaults to True.
+    Returns
+    -------
+    y : (n_samples, n_channels) np.array
+        Audio samples.
+    sample_rate : int
+        Sampling rate.
+    Notes
+    -----
+    """
+
+    y, file_sample_rate = sf.read(
+        current_file, dtype="float32", always_2d=True
+    )
+
+    # convert to mono
+    if mono and y.shape[1] > 1:
+        y = np.mean(y, axis=1, keepdims=True)
+
+    # resample if sample rates mismatch
+    if (sample_rate is not None) and (file_sample_rate != sample_rate):
+        if y.shape[1] == 1:
+            # librosa expects mono audio to be of shape (n,), but we have (n, 1).
+            y = librosa.core.resample(y[:, 0], file_sample_rate, sample_rate)[:, None]
+        else:
+            y = librosa.core.resample(y.T, file_sample_rate, sample_rate).T
+    else:
+        sample_rate = file_sample_rate
+
+    return y, sample_rate
+
 def load_wav(vid_path, sr, mode='train'):
 
-    #t1=timelib.time()
-    #print("start loading wav")
-    #print(sr)
-    #wav, sr_ret = librosa.load(vid_path, sr=sr)
-    #sr_ret, wav = scipy.io.wavfile.read(vid_path)
-
-    wav, sr_ret = sf.read(vid_path)
-    #sr_ret, old_audio = scipy.io.wavfile.read(vid_path)
-    #if sr_ret != sr:
-    #    new_rate = sr
-    #    number_of_samples = round(len(old_audio) * float(new_rate) / sr_ret)
-    #    wav = sps.resample(old_audio, number_of_samples)
-
-
-    #assert sr_ret == 16000, "we need same samplerate as librosa originally provided but is: " +str(sr_ret)
-    #print("finish loading wav", timelib.time()-t1)
+    wav, sr_ret = read_audio(vid_path, sample_rate=sr, mono=True)
+    
+    print("finish loading wav", timelib.time()-t1)
     if mode == 'train':
         extended_wav = np.append(wav, wav)
         if np.random.random() < 0.3:
@@ -43,8 +73,6 @@ def lin_spectogram_from_wav(wav, hop_length, win_length, n_fft=1024):
 
 
 def load_data(path, win_length=400, sr=16000, hop_length=160, n_fft=512, spec_len=250, mode='train'):
-    #print("starting loading a datum")
-    #t1 = timelib.time()
     wav = load_wav(path, sr=sr, mode=mode)
     linear_spect = lin_spectogram_from_wav(wav, hop_length, win_length, n_fft)
     mag, _ = librosa.magphase(linear_spect)  # magnitude
@@ -61,7 +89,6 @@ def load_data(path, win_length=400, sr=16000, hop_length=160, n_fft=512, spec_le
     # preprocessing, subtract mean, divided by time-wise var
     mu = np.mean(spec_mag, 0, keepdims=True)
     std = np.std(spec_mag, 0, keepdims=True)
-    #print("finished loading a datum", timelib.time() - t1)
     return (spec_mag - mu) / (std + 1e-5)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,9 +10,50 @@ import librosa
 from scipy import signal
 
 
-def load_wav(vid_path, sr, mode='train'):
-    wav, sr_ret = librosa.load(vid_path, sr=sr)
+# ===============================================
+#       code from Arsha for loading data.
+# ===============================================
+def read_audio(current_file, sample_rate=None, mono=True):
+    """Read audio file
+    Parameters
+    ----------
+    current_file : str
+    sample_rate: int, optional
+        Target sampling rate. Defaults to using native sampling rate.
+    mono : int, optional
+        Convert multi-channel to mono. Defaults to True.
+    Returns
+    -------
+    y : (n_samples, n_channels) np.array
+        Audio samples.
+    sample_rate : int
+        Sampling rate.
+    Notes
+    -----
+    """
 
+    y, file_sample_rate = sf.read(
+        current_file, dtype="float32", always_2d=True
+    )
+
+    # convert to mono
+    if mono and y.shape[1] > 1:
+        y = np.mean(y, axis=1, keepdims=True)
+
+    # resample if sample rates mismatch
+    if (sample_rate is not None) and (file_sample_rate != sample_rate):
+        if y.shape[1] == 1:
+            # librosa expects mono audio to be of shape (n,), but we have (n, 1).
+            y = librosa.core.resample(y[:, 0], file_sample_rate, sample_rate)[:, None]
+        else:
+            y = librosa.core.resample(y.T, file_sample_rate, sample_rate).T
+    else:
+        sample_rate = file_sample_rate
+
+    return y, sample_rate
+
+def load_wav(vid_path, sr, mode='train'):
+    wav, sr_ret = librosa.load(vid_path, sr=sr) #
     if mode == 'train':
         extended_wav = np.append(wav, wav)
         if np.random.random() < 0.3:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,13 +1,32 @@
 # Third Party
 import librosa
 import numpy as np
-
+import time as timelib
+import scipy
+import soundfile as sf
+import scipy.signal as sps
+from scipy import interpolate
 # ===============================================
 #       code from Arsha for loading data.
 # ===============================================
 def load_wav(vid_path, sr, mode='train'):
-    wav, sr_ret = librosa.load(vid_path, sr=sr)
-    assert sr_ret == sr
+
+    #t1=timelib.time()
+    #print("start loading wav")
+    #print(sr)
+    #wav, sr_ret = librosa.load(vid_path, sr=sr)
+    #sr_ret, wav = scipy.io.wavfile.read(vid_path)
+
+    wav, sr_ret = sf.read(vid_path)
+    #sr_ret, old_audio = scipy.io.wavfile.read(vid_path)
+    #if sr_ret != sr:
+    #    new_rate = sr
+    #    number_of_samples = round(len(old_audio) * float(new_rate) / sr_ret)
+    #    wav = sps.resample(old_audio, number_of_samples)
+
+
+    #assert sr_ret == 16000, "we need same samplerate as librosa originally provided but is: " +str(sr_ret)
+    #print("finish loading wav", timelib.time()-t1)
     if mode == 'train':
         extended_wav = np.append(wav, wav)
         if np.random.random() < 0.3:
@@ -24,6 +43,8 @@ def lin_spectogram_from_wav(wav, hop_length, win_length, n_fft=1024):
 
 
 def load_data(path, win_length=400, sr=16000, hop_length=160, n_fft=512, spec_len=250, mode='train'):
+    #print("starting loading a datum")
+    #t1 = timelib.time()
     wav = load_wav(path, sr=sr, mode=mode)
     linear_spect = lin_spectogram_from_wav(wav, hop_length, win_length, n_fft)
     mag, _ = librosa.magphase(linear_spect)  # magnitude
@@ -40,6 +61,7 @@ def load_data(path, win_length=400, sr=16000, hop_length=160, n_fft=512, spec_le
     # preprocessing, subtract mean, divided by time-wise var
     mu = np.mean(spec_mag, 0, keepdims=True)
     std = np.std(spec_mag, 0, keepdims=True)
+    #print("finished loading a datum", timelib.time() - t1)
     return (spec_mag - mu) / (std + 1e-5)
 
 

--- a/tool/toolkits.py
+++ b/tool/toolkits.py
@@ -102,6 +102,16 @@ def get_voxceleb2_datalist(args, path):
         f.close()
     return audiolist, labellist
 
+def get_zalo_datalist(args, path):
+    with open(path) as f:
+        strings = f.readlines()
+        audiolist = np.array([os.path.join(args.data_path, string.split()[0]) for string in strings])
+        labellist = np.array([int(string.split()[1]) for string in strings])
+        f.close()
+    print("Getting audio, e.g.", audiolist[0:5])
+    print("Getting labels, e.g.", labellist[0:5])
+    return audiolist, labellist
+
 
 def calculate_eer(y, y_score):
     # y denotes groundtruth scores,


### PR DESCRIPTION
The later version of librosa can resample wav files much faster, and to install this we need to install `llvmlite==0.31.0` via conda, so updated the requirements.txt

Librosa 0.7+ causes librosa.util.exceptions.ParameterError: Audio buffer is not Fortran-contiguous. Use numpy.asfortranarray to ensure Fortran contiguity. error

So 0.6.3 chosen. 